### PR TITLE
Add Codex support and ingest-tweets skill

### DIFF
--- a/Sources/Wikiwise/Resources/scaffold/AGENTS.md
+++ b/Sources/Wikiwise/Resources/scaffold/AGENTS.md
@@ -2,6 +2,8 @@
 
 This is a wiki maintained by an LLM agent. Read `CLAUDE.md` for the full schema, conventions, and workflows.
 
+This file exists so that **any** LLM coding agent — Claude Code, OpenAI Codex, Cursor, Windsurf, Copilot CLI, or others — can operate this wiki. If your agent reads `CLAUDE.md` natively (Claude Code does), great. If not, everything you need is here plus the skill files referenced below.
+
 ## Quick reference
 
 - **`raw/`** — immutable source documents. Read-only.
@@ -15,17 +17,80 @@ This is a wiki maintained by an LLM agent. Read `CLAUDE.md` for the full schema,
 - Cite sources inline: `([[source-slug]])`.
 - Wiki pages are short blog posts, not reference dumps. TL;DR first, then the argument.
 - After any ingest, update `wiki/index.md` and append to `wiki/log.md`.
+- Log entry format: `## [YYYY-MM-DD HH:MM] <op> | <title>`.
+- Voice: opinionated, direct, declarative. Most pages under 800 words.
+
+## Tool mapping
+
+Skills reference Claude Code tool names. If you're running a different agent, use the equivalent:
+
+| Claude Code | Codex CLI | Copilot CLI | Generic |
+|---|---|---|---|
+| `Read` | `read_file` | `read_file` | read a file |
+| `Write` | `write_file` | `write_file` | write/create a file |
+| `Edit` | `write_file` (partial) | `patch` | edit part of a file |
+| `Bash(*)` | `shell` | `run_command` | run a shell command |
+| `Glob` | `shell` + `find` | `run_command` + `find` | find files by pattern |
+| `Grep` | `shell` + `grep`/`rg` | `run_command` + `grep` | search file contents |
+| `Agent` (subagent) | N/A | N/A | do it inline |
+
+When a skill says `allowed-tools: Bash(*) Read Write Edit Glob Grep`, that's Claude Code syntax. In other agents, just use whatever tools let you run shell commands and read/write files.
 
 ## Skills
 
-Agent skills are in `.claude/skills/`. If your agent supports skill files, these should be available automatically. Otherwise, read them for workflow instructions:
+Detailed skill files live in `.claude/skills/<name>/SKILL.md`. **Read the skill file before running a workflow** — it contains step-by-step instructions, shell commands, and rules.
 
-- `ingest/` — add a source to the wiki
-- `lint/` — health-check for contradictions and orphans
-- `import-readwise/` — search and import from Readwise (orchestrator)
-- `fetch-readwise-document/` — stream a Reader document into raw/ without loading the body into context
-- `fetch-readwise-highlights/` — vector-search highlights, group by parent doc, write to raw/
+### How to use skills
+
+- **Claude Code**: Skills are auto-discovered from `.claude/skills/`. Invoke with `/ingest`, `/lint`, etc.
+- **Codex / other agents**: Read the skill file manually — e.g., read `.claude/skills/ingest/SKILL.md` — then follow its instructions. The skill files are plain markdown with step-by-step workflows.
+
+### Skill catalog
+
+| Skill | Path | Purpose |
+|---|---|---|
+| **ingest** | `.claude/skills/ingest/SKILL.md` | Add a source to the wiki — save raw, create summary page, propagate claims, update index and log |
+| **digest** | `.claude/skills/digest/SKILL.md` | Deep-propagate ingested sources across the wiki — update concept/entity pages, flag contradictions, create new pages where warranted |
+| **lint** | `.claude/skills/lint/SKILL.md` | Health-check for contradictions, orphan pages, broken links, stale claims, missing cross-links |
+| **ingest-tweets** | `.claude/skills/ingest-tweets/SKILL.md` | Search Twitter/X for tweets on a topic using browser automation, extract content, and ingest into the wiki |
+| **import-readwise** | `.claude/skills/import-readwise/SKILL.md` | Search and import documents/highlights from Readwise (orchestrator — delegates to fetch skills below) |
+| **fetch-readwise-document** | `.claude/skills/fetch-readwise-document/SKILL.md` | Stream a Reader document into `raw/` without loading the body into context |
+| **fetch-readwise-highlights** | `.claude/skills/fetch-readwise-highlights/SKILL.md` | Vector-search highlights, group by parent doc, write to `raw/` |
+
+### Workflow cheat sheet
+
+These are abbreviated versions. Read the full skill files for details.
+
+**Ingest a source:**
+1. Save raw source to `raw/<slug>.md`
+2. Create source-summary page at `wiki/sources/<slug>.md` with frontmatter (`type`, `date`, `author`, `url`, `raw`)
+3. Propagate claims into concept/entity pages with citations `([[slug]])`
+4. Update `wiki/index.md` — add new pages with one-line summaries
+5. Append to `wiki/log.md` — `## [YYYY-MM-DD HH:MM] ingest | <title>`
+
+**Lint the wiki:**
+1. Scan `wiki/` for contradictions, orphan pages, broken `[[wikilinks]]`, stale claims, missing cross-links
+2. Report findings grouped by category
+3. Append to `wiki/log.md` — `## [YYYY-MM-DD HH:MM] lint | <summary>`
+
+**Ingest tweets:**
+1. Open Twitter/X search via browser automation
+2. Scroll and extract 10-20 tweets (author, date, text, engagement, URL)
+3. Present to user for curation
+4. Save to `raw/tweets_<topic>_<date>.md`
+5. Chain into ingest — source-summary uses `type: tweets` and synthesizes the discourse
 
 ## Running your agent
 
 WikiWise includes a built-in terminal in the right sidebar — click the terminal icon in the toolbar. You can also run your agent in any external terminal pointed at this folder.
+
+```bash
+# Claude Code
+claude
+
+# Codex
+codex
+
+# Any agent — just cd to the wiki folder first
+cd /path/to/your-wiki
+```

--- a/Sources/Wikiwise/Resources/scaffold/skills/digest/SKILL.md
+++ b/Sources/Wikiwise/Resources/scaffold/skills/digest/SKILL.md
@@ -16,17 +16,19 @@ Goal: take one or more raw files that already have a wiki summary page (created 
 ## Preconditions
 
 - At least one source-summary page in `wiki/` whose claims haven't been fully propagated.
-- You have read `CLAUDE.md` and `wiki/home.md` at least once in this session.
+- You have read the wiki schema (`CLAUDE.md` or `AGENTS.md`) and `wiki/home.md` at least once in this session.
 
 ## Architecture
 
-Delegate the heavy lifting to a **subagent**. The main thread's job is:
+If your agent supports subagents (e.g., Claude Code's `Agent` tool), delegate the heavy lifting:
 1. Identify which sources need digesting.
-2. Read `CLAUDE.md`, `wiki/home.md`, and `wiki/index.md` to understand the current wiki state.
+2. Read the wiki schema, `wiki/home.md`, and `wiki/index.md` to understand the current wiki state.
 3. Dispatch a subagent with a tight brief (see template below).
 4. Receive the subagent's report and relay it concisely to the user.
 
 **Why delegate:** the main thread should not hold multiple source bodies simultaneously. The subagent reads sources once, makes surgical edits, and returns a diff summary.
+
+If your agent does **not** support subagents (e.g., Codex, Cursor), do the work inline — read the schema, identify sources, and make the edits yourself following the same rules in the subagent brief below.
 
 ## Step 1 — Identify sources to digest
 
@@ -41,17 +43,17 @@ Confirm with the user before digesting if there's ambiguity.
 
 ## Step 2 — Load the wiki's current state
 
-Read these three files and pass their content to the subagent:
+Read these three files (and pass their content to the subagent, if using one):
 
-- `CLAUDE.md` — schema, conventions.
+- `CLAUDE.md` (or `AGENTS.md`) — schema, conventions.
 - `wiki/home.md` — current through-line and live tensions.
 - `wiki/index.md` — full catalog of existing pages.
 
-## Step 3 — Dispatch the digest subagent
+## Step 3 — Dispatch the digest subagent (or do it inline)
 
-Launch a subagent with this brief (adapt per run):
+If using subagents, launch one with this brief (adapt per run). Otherwise, follow these same instructions yourself:
 
-> **Job:** Digest source(s) into the wiki. Follow `CLAUDE.md` exactly.
+> **Job:** Digest source(s) into the wiki. Follow the wiki schema (`CLAUDE.md` / `AGENTS.md`) exactly.
 >
 > **Sources to digest:** `<list of wiki source-summary pages>`
 >
@@ -76,9 +78,9 @@ Launch a subagent with this brief (adapt per run):
 > **Rules:**
 >
 > - **Never modify `raw/`.** Read-only.
-> - **Stay flat.** No subdirectories inside `wiki/`.
+> - **Stay flat.** No new subdirectories inside `wiki/` — `wiki/sources/` is the only allowed subdirectory.
 > - **Don't invent facts.** If the source doesn't say something, don't claim it.
-> - **Don't touch `CLAUDE.md` or `home.md`** unless the source forces a schema change (rare — flag it, don't just do it).
+> - **Don't touch schema files (`CLAUDE.md`, `AGENTS.md`) or `home.md`** unless the source forces a schema change (rare — flag it, don't just do it).
 > - **Don't rewrite existing pages wholesale.** Surgical edits only.
 > - **Don't duplicate content across pages.** One canonical home per claim, others link.
 >
@@ -101,11 +103,10 @@ Then ask the user if anything needs adjustment.
 
 ## Batching multiple sources
 
-If multiple sources need digesting, dispatch **one** subagent for all of them rather than one per source. Cross-references between sources stay coherent that way.
+If multiple sources need digesting and you're using subagents, dispatch **one** subagent for all of them rather than one per source. Cross-references between sources stay coherent that way.
 
 ## Rules
 
-- **Never** pre-read raws in the main thread before dispatching. The subagent reads them.
-- **Never** skip Step 2. The subagent needs that context.
+- **Never** skip Step 2. You (or the subagent) need that context.
 - **Never** run this on a source without an existing summary page — run `ingest` first.
-- **Prefer one subagent for all sources** over N subagents for N sources.
+- If using subagents: **never** pre-read raws in the main thread before dispatching. The subagent reads them. Prefer one subagent for all sources over N subagents for N sources.

--- a/Sources/Wikiwise/Resources/scaffold/skills/ingest-tweets/SKILL.md
+++ b/Sources/Wikiwise/Resources/scaffold/skills/ingest-tweets/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ingest-tweets
+description: Search Twitter/X for tweets on a topic using browser automation (Claude for Chrome or Chrome DevTools MCP), extract the content, and ingest it into the wiki as a source.
+---
+
+# Ingest tweets on a topic
+
+Use browser automation to search Twitter/X for tweets about a topic the user specifies, extract the interesting ones, and run them through the standard ingest pipeline.
+
+## Prerequisites
+
+The user must have **one** of these browser MCP tools available:
+
+- `mcp__claude-in-chrome__*` (Claude for Chrome extension)
+- `mcp__chrome-devtools__*` (Chrome DevTools MCP server)
+
+Detect which is available by checking for either toolset. If neither is present, tell the user they need a browser automation MCP connected and stop.
+
+## Step 1 — Open Twitter search
+
+Navigate to Twitter/X search for the user's topic:
+
+```
+https://x.com/search?q=<url-encoded-query>&src=typed_query&f=top
+```
+
+Use `f=top` (Top tweets) by default. If the user asks for recency, use `f=live`.
+
+Wait for the page to load and the tweet feed to render.
+
+## Step 2 — Read and scroll the feed
+
+Read the visible tweets from the page. Each tweet needs:
+
+- **Author** — display name and @handle
+- **Date** — timestamp
+- **Text** — full tweet body (expand "Show more" if truncated)
+- **Engagement** — likes, retweets, replies (rough numbers are fine)
+- **URL** — `https://x.com/<handle>/status/<id>`
+
+Scroll down 2-3 times to collect more tweets. Aim for **10-20 tweets** unless the user specified a different amount.
+
+If Twitter shows a login wall or CAPTCHA, stop and tell the user — they need to be logged in on that browser.
+
+## Step 3 — Curate
+
+Present the collected tweets to the user as a numbered list with author, date, and a one-line summary of each. Ask which ones to ingest, or confirm "all" if the user said to grab everything.
+
+## Step 4 — Save to raw/
+
+Write a single raw file at `raw/tweets_<topic-slug>_<YYYY-MM-DD>.md` containing all selected tweets in this format:
+
+```markdown
+# Tweets: <Topic>
+
+**Collected:** YYYY-MM-DD HH:MM
+**Query:** <the search query used>
+**Source:** https://x.com/search?q=<query>
+
+---
+
+## @handle — YYYY-MM-DD
+
+> Full tweet text here, preserving line breaks.
+
+Likes: N · Retweets: N · Replies: N
+Source: https://x.com/handle/status/id
+
+---
+
+## @handle2 — YYYY-MM-DD
+
+> Next tweet...
+
+...
+```
+
+## Step 5 — Ingest
+
+Invoke the `ingest` skill on the raw file. The source-summary page should:
+
+- Use `type: tweets` in frontmatter.
+- Summarize the overall discourse — what are people saying, where do they agree/disagree, what's the dominant take vs. contrarian takes.
+- Attribute specific claims to specific authors with tweet URLs.
+
+## Tips
+
+- **Thread detection:** If a tweet is part of a thread (reply chain from the same author), try to grab the full thread by clicking into it and reading the chain. Note it as a thread in the raw file.
+- **Quote tweets:** Include the quoted tweet inline, indented, so the context is preserved.
+- **Images/media:** Note `[image]`, `[video]`, or `[link preview: <url>]` inline — don't try to download media.
+- **Multiple searches:** If the topic is broad, the user may want you to run multiple queries (e.g., the topic name, key people associated with it, related hashtags). Ask if one query is enough or if they want to cast a wider net.
+
+## Rules
+
+- **Never** fabricate tweets. Only include content actually visible on the page.
+- **Never** `Read` a `raw/` file you just wrote unless the user asks.
+- **Stop and ask** if fewer than 3 tweets are found — the topic may need a different query.
+- **Respect the user's curation choices** in Step 3 — don't silently drop or add tweets.

--- a/Sources/Wikiwise/WikiScaffold.swift
+++ b/Sources/Wikiwise/WikiScaffold.swift
@@ -4,7 +4,7 @@ import Foundation
 ///   raw/
 ///   wiki/  (home.md, index.md, log.md)
 ///   site/  (build.js, style.css, out/)
-///   .claude/skills/  (ingest.md, lint.md, import-readwise.md)
+///   .claude/skills/  (ingest, digest, lint, ingest-tweets, import-readwise, ...)
 ///   CLAUDE.md
 enum WikiScaffold {
 
@@ -70,7 +70,7 @@ enum WikiScaffold {
         }
 
         // Claude Code skills (each is a directory with SKILL.md)
-        let skillDirs = ["ingest", "lint", "import-readwise", "fetch-readwise-document", "fetch-readwise-highlights"]
+        let skillDirs = ["ingest", "digest", "lint", "ingest-tweets", "import-readwise", "fetch-readwise-document", "fetch-readwise-highlights"]
         for skill in skillDirs {
             let source = scaffoldDir.appendingPathComponent("skills/\(skill)")
             let dest = url.appendingPathComponent(".claude/skills/\(skill)")


### PR DESCRIPTION
## Summary

- **Expanded `AGENTS.md`** from a brief pointer into a full cross-agent instruction file — Codex, Cursor, Copilot CLI, and other agents can now operate the wiki without relying on Claude Code-specific features. Includes a tool mapping table, skill catalog with file paths, and abbreviated workflow cheat sheets.
- **New `ingest-tweets` skill** — uses browser automation (Claude for Chrome or Chrome DevTools MCP) to search Twitter/X, extract tweets on a topic, and pipe them through the standard ingest pipeline.
- **Fixed skill copying** — `digest` and `ingest-tweets` were scaffold resources but weren't being copied into new wikis. Added both to `WikiScaffold.swift`.

## Test plan

- [ ] Create a new wiki and verify all 7 skill directories appear in `.claude/skills/`
- [ ] Open the wiki folder with Codex CLI and confirm it reads `AGENTS.md` and can find skill files
- [ ] Run `/ingest-tweets` in Claude Code with a browser MCP connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)