### PR TITLE
Add Cmd+R refresh and .rebuild trigger for agents

### DIFF
--- a/Sources/Wikiwise/ContentView.swift
+++ b/Sources/Wikiwise/ContentView.swift
@@ -171,6 +171,11 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .goForward)) { _ in
             goForward()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .refreshWiki)) { _ in
+            if let c = compiler {
+                recompileCurrentPage(c)
+            }
+        }
         .sheet(isPresented: $showNewWikiSheet) {
             newWikiSheet
         }
@@ -981,6 +986,33 @@ struct ContentView: View {
                 if let current = selectedFileURL,
                    changedPaths.contains(current.path) {
                     recompileCurrentPage(c)
+                }
+                startBackgroundCompilation(c)
+
+            case .rebuild:
+                print("[watcher] Rebuild triggered — full recompile")
+                c.rescan()
+                c.invalidateAll()
+                if selectedFileURL != nil {
+                    recompileCurrentPage(c)
+                }
+                if let root = rootURL {
+                    let previousExpanded = expandedFolders
+                    tree = scanOneLevel(at: root)
+                    let newFolderURLs = Set(tree.filter { $0.isDirectory }.map { $0.url })
+                    expandedFolders = previousExpanded.intersection(newFolderURLs)
+                    for node in tree where node.isDirectory {
+                        if expandedFolders.contains(node.url) {
+                            if let kids = node.children, kids.isEmpty {
+                                expandNode(node)
+                            }
+                        }
+                    }
+                    let snapshot = tree; tree = []; tree = snapshot
+                }
+                // Delete the trigger file after processing
+                if let root = rootURL {
+                    try? FileManager.default.removeItem(at: root.appendingPathComponent(".rebuild"))
                 }
                 startBackgroundCompilation(c)
 

--- a/Sources/Wikiwise/ContentView.swift
+++ b/Sources/Wikiwise/ContentView.swift
@@ -991,48 +991,22 @@ struct ContentView: View {
 
             case .rebuild:
                 print("[watcher] Rebuild triggered — full recompile")
+                // Delete trigger file first so a second touch during rebuild is not lost
+                if let root = rootURL {
+                    try? FileManager.default.removeItem(at: root.appendingPathComponent(".rebuild"))
+                }
                 c.rescan()
                 c.invalidateAll()
                 if selectedFileURL != nil {
                     recompileCurrentPage(c)
                 }
-                if let root = rootURL {
-                    let previousExpanded = expandedFolders
-                    tree = scanOneLevel(at: root)
-                    let newFolderURLs = Set(tree.filter { $0.isDirectory }.map { $0.url })
-                    expandedFolders = previousExpanded.intersection(newFolderURLs)
-                    for node in tree where node.isDirectory {
-                        if expandedFolders.contains(node.url) {
-                            if let kids = node.children, kids.isEmpty {
-                                expandNode(node)
-                            }
-                        }
-                    }
-                    let snapshot = tree; tree = []; tree = snapshot
-                }
-                // Delete the trigger file after processing
-                if let root = rootURL {
-                    try? FileManager.default.removeItem(at: root.appendingPathComponent(".rebuild"))
-                }
+                refreshTree()
                 startBackgroundCompilation(c)
 
             case .structure:
                 print("[watcher] Files added/deleted — rescanning")
                 c.rescan()
-                if let root = rootURL {
-                    let previousExpanded = expandedFolders
-                    tree = scanOneLevel(at: root)
-                    let newFolderURLs = Set(tree.filter { $0.isDirectory }.map { $0.url })
-                    expandedFolders = previousExpanded.intersection(newFolderURLs)
-                    for node in tree where node.isDirectory {
-                        if expandedFolders.contains(node.url) {
-                            if let kids = node.children, kids.isEmpty {
-                                expandNode(node)
-                            }
-                        }
-                    }
-                    let snapshot = tree; tree = []; tree = snapshot
-                }
+                refreshTree()
                 // Don't recompile current page on structure changes —
                 // new/deleted files don't affect the page being viewed
                 startBackgroundCompilation(c)
@@ -1040,6 +1014,23 @@ struct ContentView: View {
         }
         watcher.start()
         fileWatcher = watcher
+    }
+
+    /// Rescan the sidebar file tree, preserving which folders are expanded.
+    private func refreshTree() {
+        guard let root = rootURL else { return }
+        let previousExpanded = expandedFolders
+        tree = scanOneLevel(at: root)
+        let newFolderURLs = Set(tree.filter { $0.isDirectory }.map { $0.url })
+        expandedFolders = previousExpanded.intersection(newFolderURLs)
+        for node in tree where node.isDirectory {
+            if expandedFolders.contains(node.url) {
+                if let kids = node.children, kids.isEmpty {
+                    expandNode(node)
+                }
+            }
+        }
+        let snapshot = tree; tree = []; tree = snapshot
     }
 
     /// Force-recompile and reload the currently displayed page.

--- a/Sources/Wikiwise/FileWatcher.swift
+++ b/Sources/Wikiwise/FileWatcher.swift
@@ -85,7 +85,9 @@ final class FileWatcher {
 
             let filename = (path as NSString).lastPathComponent
 
-            if filename == ".rebuild" {
+            if filename == ".rebuild"
+                && path == watcher.watchedDir + "/.rebuild"
+                && (flag & kFSEventStreamEventFlagItemRemoved) == 0 {
                 watcher.pendingRebuild = true
             } else if path.hasSuffix(".css") {
                 watcher.pendingCSS = true

--- a/Sources/Wikiwise/FileWatcher.swift
+++ b/Sources/Wikiwise/FileWatcher.swift
@@ -8,6 +8,7 @@ final class FileWatcher {
         case css                       // style.css changed
         case markdown(Set<String>)     // .md files changed (set of absolute paths)
         case structure                 // files added or deleted
+        case rebuild                   // .rebuild trigger file touched
     }
 
     private var stream: FSEventStreamRef?
@@ -18,6 +19,7 @@ final class FileWatcher {
     /// Debounce: coalesce rapid changes into a single callback per kind.
     private var pendingCSS = false
     private var pendingStructure = false
+    private var pendingRebuild = false
     private var pendingMarkdownPaths: Set<String> = []
     private var debounceWork: DispatchWorkItem?
 
@@ -83,7 +85,9 @@ final class FileWatcher {
 
             let filename = (path as NSString).lastPathComponent
 
-            if path.hasSuffix(".css") {
+            if filename == ".rebuild" {
+                watcher.pendingRebuild = true
+            } else if path.hasSuffix(".css") {
                 watcher.pendingCSS = true
             } else if path.hasSuffix(".md") {
                 let isRemoved = (flag & kFSEventStreamEventFlagItemRemoved) != 0
@@ -104,15 +108,20 @@ final class FileWatcher {
         watcher.debounceWork?.cancel()
         let hasCSS = watcher.pendingCSS
         let hasStructure = watcher.pendingStructure
+        let hasRebuild = watcher.pendingRebuild
         let mdPaths = watcher.pendingMarkdownPaths
 
         let work = DispatchWorkItem {
             watcher.pendingCSS = false
             watcher.pendingStructure = false
+            watcher.pendingRebuild = false
             watcher.pendingMarkdownPaths.removeAll()
 
-            // Structure changes are the most disruptive — handle first
-            if hasStructure {
+            // Rebuild trigger is the most disruptive — full recompile
+            if hasRebuild {
+                watcher.callback(.rebuild)
+            } else if hasStructure {
+                // Structure changes are the next most disruptive
                 watcher.callback(.structure)
             } else {
                 if hasCSS { watcher.callback(.css) }

--- a/Sources/Wikiwise/Resources/scaffold/CLAUDE.md
+++ b/Sources/Wikiwise/Resources/scaffold/CLAUDE.md
@@ -34,6 +34,20 @@ Wiki pages are short blog posts, not reference dumps. Write for a human reader w
 
 Voice: opinionated, direct, declarative. Length: most pages under 800 words.
 
+## Live viewer
+
+The user is reading this wiki in the Wikiwise app, which watches the project directory for changes. When you edit `.md` or `.css` files, the app detects the change via FSEvents and automatically recompiles and refreshes the page the user is viewing.
+
+**If auto-refresh doesn't pick up your changes**, touch the `.rebuild` trigger file at the project root:
+
+```sh
+touch .rebuild
+```
+
+This forces a full recompile of every page and refreshes the current view. The app deletes the file after processing, so it's safe to touch repeatedly. Use this after bulk operations (many files changed at once) or if you suspect the watcher missed something.
+
+**What the user sees:** `.claude/active-file` contains the relative path of the page currently open in the app. Read it to know what the user is looking at.
+
 ## Workflows
 
 **Ingest a new source.** Read it. Create/update the source-summary page at `wiki/sources/<slug>.md`. Propagate claims into relevant concept and entity pages. Update `index.md`. Append to `log.md`.

--- a/Sources/Wikiwise/Resources/scaffold/skills/upgrade/SKILL.md
+++ b/Sources/Wikiwise/Resources/scaffold/skills/upgrade/SKILL.md
@@ -9,65 +9,87 @@ Bring this wiki's scaffold files up to date with the latest Wikiwise release.
 
 ## How it works
 
-The file `.claude/scaffold-version` records the git commit SHA this wiki was created from (or last upgraded to). This skill fetches the latest scaffold from the Wikiwise GitHub repo, diffs what changed, and applies updates.
+The file `.claude/scaffold-version` records either a `created:YYYY-MM-DD` date (from initial scaffold creation) or a git commit SHA (from a previous upgrade). This skill fetches the latest scaffold from the Wikiwise GitHub repo, diffs what changed, and applies updates.
 
-## Step 1: Read the current version
+If `.claude/scaffold-version` doesn't exist, this wiki predates versioning — treat everything as potentially stale and do a full comparison.
+
+## Step 1: Get the latest commit SHA
 
 ```sh
-cat .claude/scaffold-version
+LATEST=$(curl -fsS https://api.github.com/repos/TristanH/wikiwise/commits/main 2>/dev/null \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['sha'])" 2>/dev/null)
 ```
 
-The file contains either:
-- `created:YYYY-MM-DD` — date-based (from initial scaffold creation)
-- A 40-character git commit SHA (from a previous upgrade)
-
-If the file doesn't exist, this wiki predates versioning. Treat everything as potentially stale — skip to step 2b.
-
-## Step 2: Fetch the latest scaffold
-
-### 2a: If you have a commit SHA
-
-Use the GitHub compare API to get exactly what changed in the scaffold:
-
+If `python3` is unavailable, use `grep` + `cut`:
 ```sh
-LATEST=$(curl -s https://api.github.com/repos/TristanH/wikiwise/commits/main | grep '"sha"' | head -1 | cut -d'"' -f4)
-BASE="<the SHA from scaffold-version>"
-
-curl -s "https://api.github.com/repos/TristanH/wikiwise/compare/${BASE}...${LATEST}" \
-  | python3 -c "import sys,json; [print(f['filename']) for f in json.load(sys.stdin).get('files',[]) if f['filename'].startswith('Sources/Wikiwise/Resources/scaffold/')]"
+LATEST=$(curl -fsS https://api.github.com/repos/TristanH/wikiwise/commits/main 2>/dev/null \
+  | grep '"sha"' | head -1 | cut -d'"' -f4)
 ```
 
-This gives you the exact list of scaffold files that changed. Only process those files.
-
-### 2b: If you have a date or no version
-
-Fetch the latest version of each scaffold file and compare against the local copy. Use `diff` to check what changed:
-
+Read the current version:
 ```sh
-SCAFFOLD_BASE="https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold"
-
-# Fetch and compare a file
-curl -s "${SCAFFOLD_BASE}/CLAUDE.md" > /tmp/latest-CLAUDE.md
-diff CLAUDE.md /tmp/latest-CLAUDE.md
+BASE=$(cat .claude/scaffold-version 2>/dev/null || echo "")
 ```
 
-Do this for each file category (skills, build tooling, CLAUDE.md, AGENTS.md). If they're identical, skip. If they differ, apply per the rules in step 3.
+## Step 2: Determine what changed
 
-### Fetching individual files
+### If BASE is a 40-character SHA
+
+Use the GitHub compare API, but filter for **both** scaffold files and build tooling:
 
 ```sh
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold/<path>"
+curl -fsS "https://api.github.com/repos/TristanH/wikiwise/compare/${BASE}...${LATEST}" \
+  | python3 -c "
+import sys, json
+files = json.load(sys.stdin).get('files', [])
+for f in files:
+    name = f['filename']
+    if name.startswith('Sources/Wikiwise/Resources/scaffold/') or name.startswith('Sources/Wikiwise/Resources/') and name.count('/') == 4:
+        print(name)
+"
 ```
 
-For build tooling files that live outside the scaffold in the repo:
+This catches changes to both scaffold templates (`scaffold/CLAUDE.md`, `scaffold/skills/...`) and build tooling (`Resources/build.js`, `Resources/style.css`, etc.).
+
+### If BASE is `created:...` or missing
+
+Do a full comparison — fetch every scaffold and tooling file from GitHub and diff against local copies. See the fetch helper below.
+
+## Fetching files safely
+
+Always download to a temp file first, validate it's not an error response, then move into place:
+
 ```sh
-# These are copied from Resources/, not Resources/scaffold/
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/build.js"
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/style.css"
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/app.js"
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/graph.js"
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map.html"
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map-3d.html"
+fetch_file() {
+  local url="$1" dest="$2"
+  local tmp=$(mktemp)
+  if curl -fsS "$url" -o "$tmp" 2>/dev/null && [ -s "$tmp" ]; then
+    mv "$tmp" "$dest"
+    return 0
+  else
+    rm -f "$tmp"
+    echo "WARN: failed to fetch $url"
+    return 1
+  fi
+}
+```
+
+### Scaffold file URLs
+
+Scaffold templates (CLAUDE.md, AGENTS.md, skills, wiki seed files):
+```
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold/<path>
+```
+
+Build tooling (these live outside scaffold/ in Resources/):
+```
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/build.js
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/style.css
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/app.js
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/graph.js
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map.html
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map-3d.html
+https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/markdown-it.min.js
 ```
 
 ## Step 3: Categorize and apply changes
@@ -76,38 +98,45 @@ curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwi
 
 These files are tooling or agent instructions that the user doesn't customize:
 
-- `.claude/skills/*/SKILL.md` — skill definitions (overwrite entirely, also add any new skills)
+- `.claude/skills/*/SKILL.md` — skill definitions (overwrite entirely, also add any **new** skills that didn't exist before)
 - `site/build.js` — the wiki compiler
 - `site/style.css` — the wiki theme
-- `site/app.js`, `site/graph.js`, `site/map.html`, `site/map-3d.html` — supporting JS/HTML
+- `site/app.js`, `site/graph.js`, `site/map.html`, `site/map-3d.html`, `site/markdown-it.min.js` — supporting JS/HTML
 - `AGENTS.md` — cross-agent instructions
 - `llm-wiki.md` — reference document (read-only)
-- `.gitignore` — merge new entries (append lines that don't already exist)
 
-For each safe file, fetch the latest version and overwrite:
-
+For new skills that didn't exist when the wiki was created, create the directory and download:
 ```sh
-curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold/skills/ingest/SKILL.md" \
-  > .claude/skills/ingest/SKILL.md
+mkdir -p .claude/skills/new-skill-name
+fetch_file "${SCAFFOLD_BASE}/skills/new-skill-name/SKILL.md" ".claude/skills/new-skill-name/SKILL.md"
 ```
 
 ### Needs contextual merge (show diff, apply carefully)
 
 These files contain user-specific content and must be merged, not overwritten:
 
-- `CLAUDE.md` — contains the wiki name and possibly user-added rules. Fetch the latest template, show the user what sections changed (ignoring the `{{WIKI_NAME}}` placeholder), and apply the structural changes while preserving the wiki name and any custom additions.
-- `.claude/settings.json` — may have user-added hooks or permissions. Merge new entries.
+- `CLAUDE.md` — contains the wiki name and possibly user-added rules. Fetch the latest template, show what sections changed, and apply structural changes while preserving the wiki name and any custom additions.
 
-For CLAUDE.md specifically:
-1. Fetch the latest template from GitHub
-2. Show the diff between the template and the local file (ignoring the first heading which has the wiki name)
-3. Apply new/changed sections while preserving the wiki name in the heading and any user-added content
+For CLAUDE.md:
+1. Fetch the latest template (it has `{{WIKI_NAME}}` as a placeholder)
+2. Read the local CLAUDE.md to find the wiki name from the first heading
+3. Show the diff of everything **except** the first heading
+4. Apply new/changed sections while preserving the wiki name and user additions
 
-### Skip (user content, never touch)
+### Merge .gitignore entries
 
+`.gitignore` is generated from a string literal in the app, not a scaffold file. Instead of fetching, just ensure these entries exist (append any missing):
+```
+site/out/
+publish.json
+.rebuild
+```
+
+### Skip — do not fetch or compare
+
+- `.claude/settings.json` — generated from a string literal in the app, not a scaffold file. Only add new entries if you know what the latest settings contain. In practice, settings rarely change.
 - `wiki/` — all wiki pages are user content
 - `raw/` — immutable source documents
-- `wiki/home.md`, `wiki/index.md`, `wiki/log.md` — even the seed files, once created
 
 ## Step 4: Update the version marker
 
@@ -131,7 +160,7 @@ Summarize what was updated:
 - Files overwritten (safe updates)
 - Files merged (with what changed)
 - New skills added
-- Any files skipped or conflicts encountered
+- Any files that failed to fetch or had conflicts
 
 Append to `wiki/log.md`:
 
@@ -144,4 +173,5 @@ Append to `wiki/log.md`:
 - **Never touch `wiki/` or `raw/` content** — this skill only updates infrastructure.
 - **Always show CLAUDE.md changes** before applying — the user may have custom rules.
 - **Always trigger `.rebuild`** after upgrading so the app picks up build.js/CSS changes.
+- **Always use the safe fetch pattern** — download to temp, validate, then move. Never `curl > target` directly.
 - **If no `.claude/scaffold-version` exists**, do a full comparison and let the user review everything. Write the version file after.

--- a/Sources/Wikiwise/Resources/scaffold/skills/upgrade/SKILL.md
+++ b/Sources/Wikiwise/Resources/scaffold/skills/upgrade/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: upgrade
+description: Upgrade this wiki's scaffold files (CLAUDE.md, skills, build tooling) to match the latest Wikiwise app version from GitHub.
+---
+
+# Upgrade scaffold
+
+Bring this wiki's scaffold files up to date with the latest Wikiwise release.
+
+## How it works
+
+The file `.claude/scaffold-version` records the git commit SHA this wiki was created from (or last upgraded to). This skill fetches the latest scaffold from the Wikiwise GitHub repo, diffs what changed, and applies updates.
+
+## Step 1: Read the current version
+
+```sh
+cat .claude/scaffold-version
+```
+
+The file contains either:
+- `created:YYYY-MM-DD` — date-based (from initial scaffold creation)
+- A 40-character git commit SHA (from a previous upgrade)
+
+If the file doesn't exist, this wiki predates versioning. Treat everything as potentially stale — skip to step 2b.
+
+## Step 2: Fetch the latest scaffold
+
+### 2a: If you have a commit SHA
+
+Use the GitHub compare API to get exactly what changed in the scaffold:
+
+```sh
+LATEST=$(curl -s https://api.github.com/repos/TristanH/wikiwise/commits/main | grep '"sha"' | head -1 | cut -d'"' -f4)
+BASE="<the SHA from scaffold-version>"
+
+curl -s "https://api.github.com/repos/TristanH/wikiwise/compare/${BASE}...${LATEST}" \
+  | python3 -c "import sys,json; [print(f['filename']) for f in json.load(sys.stdin).get('files',[]) if f['filename'].startswith('Sources/Wikiwise/Resources/scaffold/')]"
+```
+
+This gives you the exact list of scaffold files that changed. Only process those files.
+
+### 2b: If you have a date or no version
+
+Fetch the latest version of each scaffold file and compare against the local copy. Use `diff` to check what changed:
+
+```sh
+SCAFFOLD_BASE="https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold"
+
+# Fetch and compare a file
+curl -s "${SCAFFOLD_BASE}/CLAUDE.md" > /tmp/latest-CLAUDE.md
+diff CLAUDE.md /tmp/latest-CLAUDE.md
+```
+
+Do this for each file category (skills, build tooling, CLAUDE.md, AGENTS.md). If they're identical, skip. If they differ, apply per the rules in step 3.
+
+### Fetching individual files
+
+```sh
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold/<path>"
+```
+
+For build tooling files that live outside the scaffold in the repo:
+```sh
+# These are copied from Resources/, not Resources/scaffold/
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/build.js"
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/style.css"
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/app.js"
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/graph.js"
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map.html"
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/map-3d.html"
+```
+
+## Step 3: Categorize and apply changes
+
+### Safe to overwrite (auto-apply)
+
+These files are tooling or agent instructions that the user doesn't customize:
+
+- `.claude/skills/*/SKILL.md` — skill definitions (overwrite entirely, also add any new skills)
+- `site/build.js` — the wiki compiler
+- `site/style.css` — the wiki theme
+- `site/app.js`, `site/graph.js`, `site/map.html`, `site/map-3d.html` — supporting JS/HTML
+- `AGENTS.md` — cross-agent instructions
+- `llm-wiki.md` — reference document (read-only)
+- `.gitignore` — merge new entries (append lines that don't already exist)
+
+For each safe file, fetch the latest version and overwrite:
+
+```sh
+curl -s "https://raw.githubusercontent.com/TristanH/wikiwise/main/Sources/Wikiwise/Resources/scaffold/skills/ingest/SKILL.md" \
+  > .claude/skills/ingest/SKILL.md
+```
+
+### Needs contextual merge (show diff, apply carefully)
+
+These files contain user-specific content and must be merged, not overwritten:
+
+- `CLAUDE.md` — contains the wiki name and possibly user-added rules. Fetch the latest template, show the user what sections changed (ignoring the `{{WIKI_NAME}}` placeholder), and apply the structural changes while preserving the wiki name and any custom additions.
+- `.claude/settings.json` — may have user-added hooks or permissions. Merge new entries.
+
+For CLAUDE.md specifically:
+1. Fetch the latest template from GitHub
+2. Show the diff between the template and the local file (ignoring the first heading which has the wiki name)
+3. Apply new/changed sections while preserving the wiki name in the heading and any user-added content
+
+### Skip (user content, never touch)
+
+- `wiki/` — all wiki pages are user content
+- `raw/` — immutable source documents
+- `wiki/home.md`, `wiki/index.md`, `wiki/log.md` — even the seed files, once created
+
+## Step 4: Update the version marker
+
+After applying all changes:
+
+```sh
+echo "$LATEST" > .claude/scaffold-version
+```
+
+## Step 5: Trigger a rebuild
+
+```sh
+touch .rebuild
+```
+
+This tells the Wikiwise app to recompile everything with the updated build tooling.
+
+## Step 6: Report
+
+Summarize what was updated:
+- Files overwritten (safe updates)
+- Files merged (with what changed)
+- New skills added
+- Any files skipped or conflicts encountered
+
+Append to `wiki/log.md`:
+
+```
+## [YYYY-MM-DD HH:MM] upgrade | scaffold updated to <short-sha>
+```
+
+## Rules
+
+- **Never touch `wiki/` or `raw/` content** — this skill only updates infrastructure.
+- **Always show CLAUDE.md changes** before applying — the user may have custom rules.
+- **Always trigger `.rebuild`** after upgrading so the app picks up build.js/CSS changes.
+- **If no `.claude/scaffold-version` exists**, do a full comparison and let the user review everything. Write the version file after.

--- a/Sources/Wikiwise/WikiScaffold.swift
+++ b/Sources/Wikiwise/WikiScaffold.swift
@@ -70,7 +70,7 @@ enum WikiScaffold {
         }
 
         // Claude Code skills (each is a directory with SKILL.md)
-        let skillDirs = ["ingest", "digest", "lint", "ingest-tweets", "import-readwise", "fetch-readwise-document", "fetch-readwise-highlights"]
+        let skillDirs = ["ingest", "digest", "lint", "ingest-tweets", "import-readwise", "fetch-readwise-document", "fetch-readwise-highlights", "upgrade"]
         for skill in skillDirs {
             let source = scaffoldDir.appendingPathComponent("skills/\(skill)")
             let dest = url.appendingPathComponent(".claude/skills/\(skill)")
@@ -121,6 +121,13 @@ enum WikiScaffold {
                 try fm.copyItem(at: source, to: url.appendingPathComponent(file.dest))
             }
         }
+
+        // Scaffold version marker — records when this wiki was created so /upgrade
+        // can diff against the latest scaffold on GitHub.
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+        let versionInfo = "created:\(dateFormatter.string(from: Date()))\n"
+        try versionInfo.write(to: url.appendingPathComponent(".claude/scaffold-version"), atomically: true, encoding: .utf8)
 
         // .gitignore for compiled output
         let gitignore = "site/out/\npublish.json\n.rebuild\n"

--- a/Sources/Wikiwise/WikiScaffold.swift
+++ b/Sources/Wikiwise/WikiScaffold.swift
@@ -123,7 +123,7 @@ enum WikiScaffold {
         }
 
         // .gitignore for compiled output
-        let gitignore = "site/out/\npublish.json\n"
+        let gitignore = "site/out/\npublish.json\n.rebuild\n"
         try gitignore.write(to: url.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
     }
 }

--- a/Sources/Wikiwise/WikiwiseApp.swift
+++ b/Sources/Wikiwise/WikiwiseApp.swift
@@ -5,6 +5,7 @@ extension Notification.Name {
     static let openFolder = Notification.Name("openFolder")
     static let goBack = Notification.Name("goBack")
     static let goForward = Notification.Name("goForward")
+    static let refreshWiki = Notification.Name("refreshWiki")
 }
 
 @main
@@ -41,6 +42,13 @@ struct WikiwiseApp: App {
                     NotificationCenter.default.post(name: .goForward, object: nil)
                 }
                 .keyboardShortcut("]", modifiers: .command)
+
+                Divider()
+
+                Button("Refresh Page") {
+                    NotificationCenter.default.post(name: .refreshWiki, object: nil)
+                }
+                .keyboardShortcut("r", modifiers: .command)
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Cmd+R refresh**: Menu item + keyboard shortcut to force-recompile and reload the current page
- **`.rebuild` trigger file**: Agents can `touch .rebuild` at the wiki root to force a full recompile — the app detects it, recompiles everything, refreshes the view, then deletes the file
- **Scaffold CLAUDE.md**: New "Live viewer" section telling agents about FSEvents auto-refresh, the `.rebuild` escape hatch, and `.claude/active-file`

## Test plan
- [ ] Open a wiki, press Cmd+R — current page should recompile and refresh
- [ ] Run `touch .rebuild` in a wiki directory — app should do a full recompile and the `.rebuild` file should be deleted afterward
- [ ] Create a new wiki — verify the scaffold CLAUDE.md contains the "Live viewer" section
- [ ] Verify `.rebuild` is in the generated `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)