### PR TITLE
Custom subdomain picker for wiki publishing

### DIFF
--- a/Sources/Wikiwise/ContentView.swift
+++ b/Sources/Wikiwise/ContentView.swift
@@ -127,6 +127,8 @@ struct ContentView: View {
     @State private var isPublishing = false
     @State private var showPublishConfirm = false
     @State private var pendingSubdomain = ""
+    @State private var subdomainAvailability: SubdomainAvailability = .unknown
+    @State private var availabilityCheckWork: DispatchWorkItem? = nil
     @State private var publishResult: PublishResult? = nil
     @State private var publishError: String? = nil
     @State private var publishConfig: PublishConfig? = nil
@@ -519,8 +521,15 @@ struct ContentView: View {
 
                     Button {
                         if publishConfig == nil {
+                            // First publish — show sheet to pick subdomain
+                            showPublishConfirm = true
+                        } else if NSEvent.modifierFlags.contains(.option) {
+                            // Option-click — show sheet to change subdomain
+                            pendingSubdomain = publishConfig?.subdomain ?? ""
+                            subdomainAvailability = .owned
                             showPublishConfirm = true
                         } else {
+                            // Normal re-publish to same subdomain
                             performPublish()
                         }
                     } label: {
@@ -550,7 +559,7 @@ struct ContentView: View {
                     }
                     .buttonStyle(.plain)
                     .disabled(isPublishing || compiler == nil)
-                    .help(publishConfig.map { "Last published: \($0.lastPublishedAt ?? "never")\n\($0.url)" } ?? "Publish wiki to wiki-wise.com")
+                    .help(publishConfig.map { "Last published: \($0.lastPublishedAt ?? "never")\n\($0.url)\n\u{2325}-click to change URL" } ?? "Publish wiki to wiki-wise.com")
 
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
@@ -1076,7 +1085,7 @@ struct ContentView: View {
         publishConfig = try? Publisher.loadConfig(projectRoot: root)
     }
 
-    private func performPublish() {
+    private func performPublish(subdomain: String? = nil) {
         guard let root = rootURL, let c = compiler else { return }
         isPublishing = true
         publishError = nil
@@ -1086,7 +1095,7 @@ struct ContentView: View {
             do {
                 // Recompile to ensure output is fresh
                 c.compileAll()
-                let result = try await Publisher.publish(siteFolder: c.outputDir, projectRoot: root)
+                let result = try await Publisher.publish(siteFolder: c.outputDir, projectRoot: root, subdomain: subdomain)
                 await MainActor.run {
                     isPublishing = false
                     publishResult = result
@@ -1107,40 +1116,138 @@ struct ContentView: View {
             Text("Publish your wiki")
                 .font(.system(size: 18, weight: .medium, design: .serif))
 
-            Text("This will make your wiki publicly available at:")
+            Text("Your wiki will be available at:")
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
 
-            Text("https://\(pendingSubdomain).wiki-wise.com")
-                .font(.system(size: 13, design: .monospaced))
-                .textSelection(.enabled)
-                .padding(8)
-                .background(RoundedRectangle(cornerRadius: 4).fill(Color.sidebarBg))
+            // Editable subdomain field
+            HStack(spacing: 0) {
+                Text("https://")
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                TextField("subdomain", text: $pendingSubdomain)
+                    .font(.system(size: 13, design: .monospaced))
+                    .textFieldStyle(.plain)
+                    .frame(maxWidth: 200)
+                    .onChange(of: pendingSubdomain) { _, newValue in
+                        // Sanitize: lowercase, only alphanumeric and hyphens
+                        let sanitized = newValue.lowercased()
+                            .filter { $0.isLetter || $0.isNumber || $0 == "-" }
+                        if sanitized != newValue {
+                            pendingSubdomain = sanitized
+                            return
+                        }
+                        checkSubdomainAvailability(sanitized)
+                    }
+                Text(".wiki-wise.com")
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(.secondary)
 
-            Text("Anyone with this link can view your wiki. A publish.json file will be saved in your project \u{2014} it contains your publish token. Treat it like a password: if you lose it, you won\u{2019}t be able to update this site.")
+                Spacer()
+
+                // Availability indicator
+                Group {
+                    switch subdomainAvailability {
+                    case .checking:
+                        ProgressView()
+                            .controlSize(.small)
+                    case .available:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    case .owned:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.blue)
+                    case .taken:
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.red)
+                    case .invalid:
+                        Image(systemName: "exclamationmark.circle.fill")
+                            .foregroundStyle(.orange)
+                    case .unknown:
+                        EmptyView()
+                    }
+                }
+                .frame(width: 16, height: 16)
+            }
+            .padding(8)
+            .background(RoundedRectangle(cornerRadius: 4).fill(Color.sidebarBg))
+
+            // Availability hint text
+            Group {
+                switch subdomainAvailability {
+                case .taken:
+                    Text("This name is already taken. Try another.")
+                        .foregroundStyle(.red)
+                case .invalid:
+                    Text("3\u{2013}48 characters, letters, numbers, and hyphens only.")
+                        .foregroundStyle(.orange)
+                case .owned:
+                    Text("You already own this name.")
+                        .foregroundStyle(.blue)
+                default:
+                    Text("Anyone with this link can view your wiki.")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .font(.system(size: 12))
+
+            Text("A publish.json file will be saved in your project \u{2014} it contains your publish token. Treat it like a password: if you lose it, you won\u{2019}t be able to update this site.")
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
                 .lineSpacing(2)
 
             HStack {
                 Spacer()
-                Button("Cancel") { showPublishConfirm = false }
-                    .keyboardShortcut(.cancelAction)
+                Button("Cancel") {
+                    showPublishConfirm = false
+                }
+                .keyboardShortcut(.cancelAction)
                 Button("Publish") {
                     showPublishConfirm = false
-                    performPublish()
+                    performPublish(subdomain: pendingSubdomain)
                 }
                 .keyboardShortcut(.defaultAction)
+                .disabled(!canPublish)
             }
         }
         .padding(24)
-        .frame(width: 440)
+        .frame(width: 480)
         .onAppear {
             if pendingSubdomain.isEmpty {
                 let wikiName = rootURL?.lastPathComponent
                 pendingSubdomain = Publisher.randomSubdomain(wikiName: wikiName)
             }
         }
+    }
+
+    private var canPublish: Bool {
+        switch subdomainAvailability {
+        case .available, .owned: return true
+        default: return false
+        }
+    }
+
+    private func checkSubdomainAvailability(_ subdomain: String) {
+        availabilityCheckWork?.cancel()
+        guard subdomain.count >= 3 else {
+            subdomainAvailability = subdomain.isEmpty ? .unknown : .invalid
+            return
+        }
+        subdomainAvailability = .checking
+        let work = DispatchWorkItem {
+            Task {
+                let token = publishConfig?.token
+                let result = await Publisher.checkAvailability(subdomain: subdomain, token: token)
+                await MainActor.run {
+                    // Only update if the subdomain hasn't changed while we were checking
+                    if pendingSubdomain == subdomain {
+                        subdomainAvailability = result
+                    }
+                }
+            }
+        }
+        availabilityCheckWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
     }
 
     // MARK: - Post-Creation Guide

--- a/Sources/Wikiwise/Publisher.swift
+++ b/Sources/Wikiwise/Publisher.swift
@@ -42,8 +42,18 @@ enum PublishError: LocalizedError {
     }
 }
 
+enum SubdomainAvailability {
+    case available
+    case taken
+    case owned    // taken but by this user's token
+    case invalid
+    case checking
+    case unknown  // not yet checked
+}
+
 final class Publisher {
     static let endpoint = URL(string: "https://publish.wiki-wise.com/_publish")!
+    static let checkEndpoint = URL(string: "https://publish.wiki-wise.com/_check")!
 
     /// Load an existing publish config, or nil if the file doesn't exist.
     /// Throws if the file exists but is malformed.
@@ -58,7 +68,35 @@ final class Publisher {
         return config
     }
 
-    static func publish(siteFolder: URL, projectRoot: URL) async throws -> PublishResult {
+    /// Check whether a subdomain is available, taken, or owned by the given token.
+    static func checkAvailability(subdomain: String, token: String? = nil) async -> SubdomainAvailability {
+        var components = URLComponents(url: checkEndpoint, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "subdomain", value: subdomain)]
+        guard let url = components.url else { return .invalid }
+
+        var request = URLRequest(url: url)
+        if let token = token {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse, http.statusCode == 200,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let reason = json["reason"] as? String else {
+            return .unknown
+        }
+
+        switch reason {
+        case "free": return .available
+        case "owned": return .owned
+        case "taken": return .taken
+        case "invalid": return .invalid
+        default: return .unknown
+        }
+    }
+
+    /// Publish the wiki, optionally overriding the subdomain.
+    static func publish(siteFolder: URL, projectRoot: URL, subdomain: String? = nil) async throws -> PublishResult {
         let configURL = projectRoot.appendingPathComponent("publish.json")
 
         var config: PublishConfig
@@ -66,14 +104,18 @@ final class Publisher {
 
         if let existing = try loadConfig(projectRoot: projectRoot) {
             config = existing
+            // Override subdomain if the user chose a custom one
+            if let sub = subdomain, sub != config.subdomain {
+                config.subdomain = sub
+                config.url = "https://\(sub).wiki-wise.com"
+            }
         } else {
-            let wikiName = projectRoot.lastPathComponent
+            let sub = subdomain ?? randomSubdomain(wikiName: projectRoot.lastPathComponent)
             config = PublishConfig(
-                subdomain: randomSubdomain(wikiName: wikiName),
+                subdomain: sub,
                 token: "ww_" + randomHex(32),
-                url: ""
+                url: "https://\(sub).wiki-wise.com"
             )
-            config.url = "https://\(config.subdomain).wiki-wise.com"
             isFirstPublish = true
         }
 


### PR DESCRIPTION
## Summary
- Editable subdomain field in the publish sheet — users can pick their own URL instead of getting a random one
- Live availability checking via new `/_check` worker endpoint (debounced 400ms)
- Visual feedback: green checkmark (available), blue checkmark (you own it), red X (taken), orange ! (invalid format)
- Option-click the PUBLISH button to change an already-published wiki's URL
- Publish button disabled until subdomain is confirmed available

## Worker changes (separate repo)
- New `GET /_check?subdomain=foo` endpoint returns `{ available, reason }` where reason is `free`, `taken`, `owned`, or `invalid`
- If caller sends `Authorization: Bearer ww_...` header, the endpoint checks token ownership and returns `owned` for subdomains the caller already controls

## Test plan
- [ ] First publish: subdomain field is editable, pre-filled with auto-generated name
- [ ] Type a custom subdomain — availability indicator appears after typing stops
- [ ] Try a taken subdomain — red X, publish button disabled
- [ ] Try a valid available subdomain — green checkmark, publish button enabled
- [ ] Complete publish with custom subdomain — verify publish.json has the chosen name
- [ ] Re-publish (normal click) — publishes immediately to same subdomain (no sheet)
- [ ] Re-publish (Option-click) — shows sheet with current subdomain editable
- [ ] Verify /_check endpoint returns correct responses for free/taken/owned/invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)