### PR TITLE
Preserve scroll position across view switches and reloads

### DIFF
--- a/Sources/Wikiwise/Compiler.swift
+++ b/Sources/Wikiwise/Compiler.swift
@@ -134,7 +134,10 @@ final class Compiler {
                 if fm.fileExists(atPath: dst) { try fm.removeItem(atPath: dst) }
                 try fm.copyItem(atPath: src, toPath: dst)
                 return true
-            } catch { return false }
+            } catch {
+                print("[compiler] copyFile failed: \(src) → \(dst): \(error)")
+                return false
+            }
         }
         jsContext.setObject(copyFile, forKeyedSubscript: "copyFile" as NSString)
 

--- a/Sources/Wikiwise/ContentView.swift
+++ b/Sources/Wikiwise/ContentView.swift
@@ -132,6 +132,9 @@ struct ContentView: View {
     @State private var backgroundTimer: Timer? = nil
     @State private var fileWatcher: FileWatcher? = nil
     @State private var webViewReloadToken: Int = 0
+    @State private var scrollFraction: Double = 0
+    /// Holds a weak ref to the active WKWebView so we can query scroll position.
+    @StateObject private var activeWebView = WebViewHolder()
     @State private var rightSidebarTab: RightSidebarTab = .terminal
     @State private var showRightSidebar: Bool = true
     @State private var showLeftSidebar: Bool = true
@@ -460,7 +463,7 @@ struct ContentView: View {
                             bottomTrailingRadius: 3, topTrailingRadius: 3
                         )
 
-                        Button { detailMode = .raw } label: {
+                        Button { captureScrollAndSwitch(to: .raw) } label: {
                             Text("FILE")
                                 .font(.system(size: 10, weight: .regular, design: .monospaced))
                                 .tracking(0.8)
@@ -472,7 +475,7 @@ struct ContentView: View {
                         }
                         .buttonStyle(.plain)
 
-                        Button { detailMode = .compiled } label: {
+                        Button { captureScrollAndSwitch(to: .compiled) } label: {
                             Text("WIKI")
                                 .font(.system(size: 10, weight: .regular, design: .monospaced))
                                 .tracking(0.8)
@@ -753,12 +756,12 @@ struct ContentView: View {
             .background(Color.contentBg)
         } else if let url = selectedFileURL, url.pathExtension.lowercased() != "md" {
             // Non-markdown files (CSS, JS, JSON) always use the code editor
-            EditorWebView(fileURL: url, fileContent: $fileContent)
+            EditorWebView(fileURL: url, fileContent: $fileContent, scrollFraction: .constant(0))
         } else {
             switch detailMode {
             case .raw:
                 if let url = selectedFileURL {
-                    EditorWebView(fileURL: url, fileContent: $fileContent)
+                    EditorWebView(fileURL: url, fileContent: $fileContent, scrollFraction: $scrollFraction, holder: activeWebView)
                 }
             case .compiled:
                 if let url = compiledFileURL, let c = compiler {
@@ -768,12 +771,27 @@ struct ContentView: View {
                         onNavigate: { htmlURL in
                             handleWikilink(htmlURL)
                         },
-                        reloadToken: webViewReloadToken
+                        reloadToken: webViewReloadToken,
+                        scrollFraction: $scrollFraction,
+                        holder: activeWebView
                     )
                 } else if let url = selectedFileURL {
                     // No compiled HTML (e.g. raw/ files) — show editor instead
-                    EditorWebView(fileURL: url, fileContent: $fileContent)
+                    EditorWebView(fileURL: url, fileContent: $fileContent, scrollFraction: .constant(0))
                 }
+            }
+        }
+    }
+
+    // MARK: - Scroll preservation
+
+    /// Capture scroll position from the active webview, then switch detail mode.
+    private func captureScrollAndSwitch(to mode: DetailMode) {
+        let isEditor = detailMode == .raw
+        activeWebView.captureScrollFraction(isEditor: isEditor) { fraction in
+            DispatchQueue.main.async {
+                scrollFraction = fraction
+                detailMode = mode
             }
         }
     }
@@ -789,6 +807,7 @@ struct ContentView: View {
             backHistory.append(compiled)
             forwardHistory = []
         }
+        scrollFraction = 0  // Reset scroll for new page
         selectedFileURL = url
         loadFile(url)
         // Force WebView to load the new page (critical when navigating

--- a/Sources/Wikiwise/EditorWebView.swift
+++ b/Sources/Wikiwise/EditorWebView.swift
@@ -7,6 +7,10 @@ import WebKit
 struct EditorWebView: NSViewRepresentable {
     let fileURL: URL
     @Binding var fileContent: String
+    /// Shared scroll fraction (0–1) for preserving position across view switches.
+    @Binding var scrollFraction: Double
+    /// Shared holder so ContentView can query scroll.
+    var holder: WebViewHolder? = nil
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -22,8 +26,10 @@ struct EditorWebView: NSViewRepresentable {
         let wv = WKWebView(frame: .zero, configuration: config)
         wv.setValue(false, forKey: "drawsBackground")
         context.coordinator.webView = wv
+        holder?.webView = wv
         context.coordinator.pendingContent = fileContent
         context.coordinator.currentFileURL = fileURL
+        context.coordinator.pendingScrollFraction = scrollFraction
 
         // Load editor.html from the resource bundle
         if let editorURL = wikiwiseBundle.url(forResource: "editor", withExtension: "html") {
@@ -39,6 +45,7 @@ struct EditorWebView: NSViewRepresentable {
         if context.coordinator.currentFileURL != fileURL {
             context.coordinator.currentFileURL = fileURL
             context.coordinator.pendingContent = fileContent
+            context.coordinator.pendingScrollFraction = scrollFraction
             if context.coordinator.isReady {
                 context.coordinator.pushContent(fileContent)
             }
@@ -51,6 +58,7 @@ struct EditorWebView: NSViewRepresentable {
         var isReady = false
         var pendingContent: String?
         var currentFileURL: URL?
+        var pendingScrollFraction: Double = 0
 
         init(_ parent: EditorWebView) {
             self.parent = parent
@@ -88,10 +96,25 @@ struct EditorWebView: NSViewRepresentable {
                 .replacingOccurrences(of: "'", with: "\\'")
                 .replacingOccurrences(of: "\n", with: "\\n")
                 .replacingOccurrences(of: "\r", with: "\\r")
-            webView?.evaluateJavaScript("setContent('\(escaped)')") { _, error in
+            let fraction = pendingScrollFraction
+            // Set content, then restore scroll position after a brief layout delay
+            webView?.evaluateJavaScript("setContent('\(escaped)')") { [weak self] _, error in
                 if let error = error {
                     print("[editor] Error setting content: \(error)")
+                    return
                 }
+                if fraction > 0.01 {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        self?.webView?.evaluateJavaScript("__scrollToFraction(\(fraction))")
+                    }
+                }
+            }
+        }
+
+        /// Capture current scroll fraction from CodeMirror.
+        func captureScroll(completion: @escaping (Double) -> Void) {
+            webView?.evaluateJavaScript("__getScrollFraction()") { result, _ in
+                completion((result as? Double) ?? 0)
             }
         }
     }

--- a/Sources/Wikiwise/Resources/build.js
+++ b/Sources/Wikiwise/Resources/build.js
@@ -340,19 +340,36 @@ function compileNextBatch(batchSize) {
   return _progressive.pending.length;
 }
 
-// Copy wiki/assets/ → site/out/assets/ (binary-safe via copyFile bridge)
+// Copy wiki/assets/ → site/out/assets/ (binary-safe via copyFile bridge).
+// Recurses into subdirectories; skips files whose mtime hasn't changed.
 function copyAssets(sourceDir, outputDir) {
   if (typeof copyFile === 'undefined') return;
   var assetsDir = sourceDir + '/wiki/assets';
   if (!fileExists(assetsDir)) return;
-  var files = listDir(assetsDir);
-  if (!files.length) return;
   var outAssets = outputDir + '/assets';
-  mkdirp(outAssets);
   var copied = 0;
-  for (var i = 0; i < files.length; i++) {
-    if (copyFile(assetsDir + '/' + files[i], outAssets + '/' + files[i])) copied++;
+
+  function copyDir(srcDir, dstDir) {
+    var entries = listDir(srcDir);
+    for (var i = 0; i < entries.length; i++) {
+      var src = srcDir + '/' + entries[i];
+      var dst = dstDir + '/' + entries[i];
+      // Recurse into subdirectories (listDir returns non-empty for dirs)
+      var children = listDir(src);
+      if (children.length > 0) {
+        copyDir(src, dst);
+        continue;
+      }
+      // Skip if destination is up to date
+      var srcMtime = fileMtime(src);
+      var dstMtime = fileMtime(dst);
+      if (dstMtime >= srcMtime && srcMtime > 0) continue;
+      mkdirp(dstDir);
+      if (copyFile(src, dst)) copied++;
+    }
   }
+
+  copyDir(assetsDir, outAssets);
   if (copied) log('Copied ' + copied + ' asset(s) to ' + outAssets);
 }
 

--- a/Sources/Wikiwise/Resources/editor.html
+++ b/Sources/Wikiwise/Resources/editor.html
@@ -27,5 +27,21 @@
 <body>
 <div id="editor"></div>
 <script src="codemirror-bundle.js"></script>
+<script>
+// Scroll fraction helpers for preserving position across view switches.
+// CodeMirror scrolls inside .cm-scroller, not the window.
+function __getScrollFraction() {
+  var s = document.querySelector('.cm-scroller');
+  if (!s) return 0;
+  var max = s.scrollHeight - s.clientHeight;
+  return max > 0 ? s.scrollTop / max : 0;
+}
+function __scrollToFraction(f) {
+  var s = document.querySelector('.cm-scroller');
+  if (!s) return;
+  var max = s.scrollHeight - s.clientHeight;
+  s.scrollTop = f * max;
+}
+</script>
 </body>
 </html>

--- a/Sources/Wikiwise/WebView.swift
+++ b/Sources/Wikiwise/WebView.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 import WebKit
 
+/// Shared holder so ContentView can query the active webview's scroll position.
+final class WebViewHolder: ObservableObject {
+    weak var webView: WKWebView?
+
+    /// JS to get scroll fraction from either a wiki page (window scroll) or CodeMirror (.cm-scroller).
+    func captureScrollFraction(isEditor: Bool, completion: @escaping (Double) -> Void) {
+        guard let wv = webView else { completion(0); return }
+        let js = isEditor
+            ? "__getScrollFraction()"
+            : "window.scrollY / Math.max(1, document.body.scrollHeight - window.innerHeight)"
+        wv.evaluateJavaScript(js) { result, _ in
+            completion((result as? Double) ?? 0)
+        }
+    }
+}
+
 private extension URL {
     /// URL without the fragment (#anchor) component.
     var deletingFragment: URL {
@@ -20,6 +36,10 @@ struct WebView: NSViewRepresentable {
     /// Increment to force a reload even when the URL hasn't changed
     /// (e.g. after CSS change recompiles the same page).
     var reloadToken: Int = 0
+    /// Shared scroll fraction (0–1) for preserving position across view switches.
+    @Binding var scrollFraction: Double
+    /// Shared holder so ContentView can query scroll.
+    var holder: WebViewHolder? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator(onNavigate: onNavigate) }
 
@@ -27,6 +47,7 @@ struct WebView: NSViewRepresentable {
         let wv = WKWebView()
         wv.navigationDelegate = context.coordinator
         wv.setValue(false, forKey: "drawsBackground")
+        holder?.webView = wv
         return wv
     }
 
@@ -36,7 +57,20 @@ struct WebView: NSViewRepresentable {
         // so CSS prefers-color-scheme responds to the manual toggle.
         wv.appearance = NSApp.effectiveAppearance
         if wv.url != fileURL || context.coordinator.lastReloadToken != reloadToken {
+            let isReload = wv.url == fileURL && context.coordinator.lastReloadToken != reloadToken
             context.coordinator.lastReloadToken = reloadToken
+            // Save scroll position before reload
+            if isReload {
+                wv.evaluateJavaScript("window.scrollY / Math.max(1, document.body.scrollHeight - window.innerHeight)") { result, _ in
+                    if let fraction = result as? Double, fraction.isFinite {
+                        context.coordinator.pendingScrollFraction = fraction
+                    }
+                }
+            } else {
+                // Switching to a new page — use the shared fraction from the binding
+                context.coordinator.pendingScrollFraction = scrollFraction
+            }
+            context.coordinator.scrollFractionBinding = $scrollFraction
             wv.loadFileURL(fileURL, allowingReadAccessTo: allowingReadAccessTo)
         }
     }
@@ -44,9 +78,31 @@ struct WebView: NSViewRepresentable {
     final class Coordinator: NSObject, WKNavigationDelegate {
         var onNavigate: ((URL) -> Void)?
         var lastReloadToken: Int = 0
+        var pendingScrollFraction: Double = 0
+        var scrollFractionBinding: Binding<Double>?
 
         init(onNavigate: ((URL) -> Void)?) {
             self.onNavigate = onNavigate
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            // Restore scroll position after page load
+            let fraction = pendingScrollFraction
+            if fraction > 0.01 {
+                // Small delay to let layout settle
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    webView.evaluateJavaScript(
+                        "window.scrollTo(0, \(fraction) * (document.body.scrollHeight - window.innerHeight))"
+                    )
+                }
+            }
+        }
+
+        /// Called by ContentView before switching away — captures current scroll.
+        func captureScroll(_ webView: WKWebView, completion: @escaping (Double) -> Void) {
+            webView.evaluateJavaScript("window.scrollY / Math.max(1, document.body.scrollHeight - window.innerHeight)") { result, _ in
+                completion((result as? Double) ?? 0)
+            }
         }
 
         func webView(


### PR DESCRIPTION
## Summary
- Scroll position (as a 0-1 fraction) is captured before switching between FILE/WIKI views and restored after the new view loads
- Scroll is also preserved on page reloads (e.g. when the file watcher recompiles after a CSS change)
- Asset pipeline improvements from code review: error logging, subdirectory recursion, mtime-based skip

## Test plan
- [ ] Open a long wiki page, scroll to middle, toggle FILE → WIKI → FILE — position should be preserved
- [ ] Edit a .md file and save — wiki view should reload without jumping to top
- [ ] Add an image to `wiki/assets/subdir/` and reference it — verify it appears in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)